### PR TITLE
techprober.minio.backup: update default user

### DIFF
--- a/changelogs/changelogs.yaml
+++ b/changelogs/changelogs.yaml
@@ -15,6 +15,10 @@ releases:
       changes:
         major_changes:
         - initial release
+    1.0.2:
+      changes:
+        major_changes:
+        - techprober.minio.backup - use ansible_user as the user to execute the backup script
   maintenance:
     1.0.0:
       changes:

--- a/collections/minio/galaxy.yml
+++ b/collections/minio/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: techprober
 name: minio
-version: 1.0.0
+version: 1.0.2
 readme: README.md
 authors:
 - Kevin Yu <kevinyu211@yahoo.com>

--- a/collections/minio/roles/backup/README.md
+++ b/collections/minio/roles/backup/README.md
@@ -36,7 +36,6 @@ minio_remote_url: "http://<host_ip>:9000"
 ```yaml
 - name: Backup Data to Minio
   hosts: all
-  become: yes
 
   roles:
     - role: techprober.minio.backup

--- a/collections/minio/roles/backup/tasks/backup.yml
+++ b/collections/minio/roles/backup/tasks/backup.yml
@@ -1,20 +1,11 @@
 ---
 - name: Backup data to minio bucket
-  command: "/home/{{ ansible_user }}/backup.sh"
-  register: nonroot_result
-  when: ansible_user != "root"
-
-- name: Backup data to minio bucket (root)
-  command: "/root/backup.sh"
-  register: root_result
-  when: ansible_user == "root"
+  command: "{{ ansible_env.HOME }}/backup.sh"
+  register: result
+  become: true
+  become_user: "{{ ansible_user }}"
 
 - name: Check if backup job has completed successfully
   ansible.builtin.debug:
     msg: "Backup ran successfully!"
-  when: nonroot_result is changed
-
-- name: Check if backup job (root) has completed successfully
-  ansible.builtin.debug:
-    msg: "Backup ran successfully!"
-  when: root_result is changed
+  when: result is changed


### PR DESCRIPTION
- patch(minio.backup): use ansible_user as the user for backup
- changelogs: released techprober.minio v1.0.2
- doc(minio.backup): updated sample playbook
